### PR TITLE
refactor: remove socket path state / usage

### DIFF
--- a/infrastructure/firecracker/state.go
+++ b/infrastructure/firecracker/state.go
@@ -26,7 +26,6 @@ type State interface {
 	MetricsPath() string
 	StdoutPath() string
 	StderrPath() string
-	SockPath() string
 
 	ConfigPath() string
 	Config() (VmmConfig, error)
@@ -75,10 +74,6 @@ func (s *fsState) StdoutPath() string {
 
 func (s *fsState) StderrPath() string {
 	return fmt.Sprintf("%s/firecracker.stderr", s.stateRoot)
-}
-
-func (s *fsState) SockPath() string {
-	return fmt.Sprintf("%s/firecracker.sock", s.stateRoot)
 }
 
 func (s *fsState) SetPid(pid int) error {


### PR DESCRIPTION

**What this PR does / why we need it**:

With the introduction of `--no-api` there is no need to specify the
socket path when starting Firecracker. Also, we don't need to wait for
the file to exist.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
